### PR TITLE
Create restock whitelist for Restock Compatibility

### DIFF
--- a/PKS.restockwhitelist
+++ b/PKS.restockwhitelist
@@ -1,0 +1,3 @@
+Squad/Parts/Resources/miniISRU/
+Squad/Parts/Resources/MiniDrill/
+Squad/Parts/Resources/RadialDrill/


### PR DESCRIPTION
Compatibility file for popular Restock mod

Restock prevents loading of stock parts and replaces them with modified versions. This mod relies on the stock parts getting loaded anyway. 
https://github.com/PorktoberRevolution/ReStocked/wiki/Asset-Blacklist-and-Whitelist#practical-example