### PR TITLE
Capitalization

### DIFF
--- a/PKS.restockwhitelist
+++ b/PKS.restockwhitelist
@@ -1,3 +1,3 @@
-Squad/Parts/Resources/miniISRU/
+Squad/Parts/Resources/MiniISRU/
 Squad/Parts/Resources/MiniDrill/
 Squad/Parts/Resources/RadialDrill/


### PR DESCRIPTION
User reported issues with small m. Restock source uses capital but it still work for me with small m. I'm not sure if it's an issue but, hey why not fix it. https://github.com/PorktoberRevolution/ReStocked/blob/285d3543f91591547a38e7d13dd88c6b57400b0f/Distribution/Restock/GameData/ReStock/Restock.restockblacklist

Edit, trying to figure out how to delete this pull request because I messed it up. Don't merge.