### PR TITLE
Move file to gamedata and capitalization

### DIFF
--- a/src/ProgressiveColonizationSystem/GameData/ProgressiveColonizationSystem/PKS.restockwhitelist
+++ b/src/ProgressiveColonizationSystem/GameData/ProgressiveColonizationSystem/PKS.restockwhitelist
@@ -1,3 +1,3 @@
-Squad/Parts/Resources/miniISRU/
+Squad/Parts/Resources/MiniISRU/
 Squad/Parts/Resources/MiniDrill/
 Squad/Parts/Resources/RadialDrill/


### PR DESCRIPTION
IDK why I thought leaving it in the root directory was a great idea. With the file in the root directory, it doesn't actually show up in the release.

User reported issues with small m. Restock source uses capital M but it still works for me with small m. I'm not sure if it's an issue but, hey why not fix it. See: https://github.com/PorktoberRevolution/ReStocked/blob/285d3543f91591547a38e7d13dd88c6b57400b0f/Distribution/Restock/GameData/ReStock/Restock.restockblacklist